### PR TITLE
Switch back to InvokeModel streaming

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,7 +35,7 @@ def bot(message, history, aws_access, aws_secret, aws_token, system_prompt, temp
     try:
         llm = LLM.create_llm(model)
         messages = llm.generate_body(message, history)
-        sys_prompt = [{"text": system_prompt}] if system_prompt else []
+        sys_prompt = system_prompt
 
         config = Config(
             read_timeout = 600,
@@ -78,18 +78,25 @@ def bot(message, history, aws_access, aws_secret, aws_token, system_prompt, temp
 
         whole_response = ""
         while True:
-            response = br.converse_stream(
+            body_dict = {
+                "anthropic_version": "bedrock-2023-05-31",
+                "messages": messages,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+            }
+            if sys_prompt:
+                body_dict["system"] = sys_prompt
+            if python_use:
+                body_dict.update(tool_config)
+
+            response = br.invoke_model_with_response_stream(
                 modelId = model,
-                messages = messages,
-                system = sys_prompt,
-                inferenceConfig = {
-                    "temperature": temperature,
-                    "maxTokens": max_tokens,
-                },
-                **({'toolConfig': tool_config} if python_use else {})
+                body = json.dumps(body_dict),
+                accept = "application/json",
+                contentType = "application/json"
             )
 
-            for stop_reason, message in llm.read_response(response.get('stream')):
+            for stop_reason, message in llm.read_response(response.get('body')):
                 if isinstance(message, str):
                     whole_response += message
                     yield whole_response

--- a/llm.py
+++ b/llm.py
@@ -17,7 +17,6 @@ import gradio
 
 # constants
 log_to_console = False
-use_document_message_type = False  # AWS document message type usage
 
 LLMClass = TypeVar('LLMClass', bound='LLM')
 
@@ -76,31 +75,9 @@ class LLM:
         return messages
 
     def _process_file(self, file_path):
-        if use_document_message_type and self._is_supported_document_type(file_path):
-            return [self._create_document_message(file_path)]
-        else:
-            return self._encode_file(file_path)
+        return self._encode_file(file_path)
 
-    def _is_supported_document_type(self, file_path):
-        supported_extensions = ['.pdf', '.csv', '.doc', '.docx', '.xls', '.xlsx', '.html', '.txt', '.md']
-        return os.path.splitext(file_path)[1].lower() in supported_extensions
 
-    def _create_document_message(self, file_path):
-        with open(file_path, 'rb') as file:
-            file_content = file.read()
-        
-        file_name = re.sub(r'[^a-zA-Z0-9\s\-\(\)\[\]]', '', os.path.basename(file_path))[:200].strip() or "unnamed_file"
-        file_extension = os.path.splitext(file_path)[1][1:]  # Remove the dot
-
-        return {
-            "document": {
-                "name": file_name,
-                "format": file_extension,
-                "source": {
-                    "bytes": file_content
-                }
-            }
-        }
 
     def _encode_file(self, fn: str) -> list:
         if fn.endswith(".docx"):
@@ -291,14 +268,21 @@ class LLM:
         stop_reason = None
 
         for chunk in response_stream:
-            if 'messageStart' in chunk:
-                message['role'] = chunk['messageStart']['role']
-            elif 'contentBlockStart' in chunk:
-                tool = chunk['contentBlockStart']['start']['toolUse']
+            if 'chunk' in chunk:
+                chunk = json.loads(chunk['chunk']['bytes'])
+
+            if 'messageStart' in chunk or chunk.get('type') == 'message_start':
+                if 'messageStart' in chunk:
+                    message['role'] = chunk['messageStart']['role']
+                else:
+                    message['role'] = chunk['message']['role']
+            elif 'contentBlockStart' in chunk or chunk.get('type') == 'content_block_start':
+                start = chunk.get('contentBlockStart', chunk.get('start'))
+                tool = start.get('toolUse') or start.get('tool_use')
                 tool_use['toolUseId'] = tool['toolUseId']
                 tool_use['name'] = tool['name']
-            elif 'contentBlockDelta' in chunk:
-                delta = chunk['contentBlockDelta']['delta']
+            elif 'contentBlockDelta' in chunk or chunk.get('type') == 'content_block_delta':
+                delta = chunk.get('contentBlockDelta', chunk.get('delta'))['delta'] if 'contentBlockDelta' in chunk else chunk['delta']
                 if 'toolUse' in delta:
                     if 'input' not in tool_use:
                         tool_use['input'] = ''
@@ -306,17 +290,18 @@ class LLM:
                 elif 'text' in delta:
                     text += delta['text']
                     yield None, delta['text']
-            elif 'contentBlockStop' in chunk:
+            elif 'contentBlockStop' in chunk or chunk.get('type') == 'content_block_stop':
                 if 'input' in tool_use:
                     tool_use['input'] = json.loads(tool_use['input'])
                     content.append({'toolUse': tool_use})
                     tool_use = {}
                 else:
                     content.append({'text': text})
-            elif 'messageStop' in chunk:
-                stop_reason = chunk['messageStop']['stopReason']
+            elif 'messageStop' in chunk or chunk.get('type') == 'message_stop':
+                stop_reason = chunk.get('messageStop', chunk).get('stopReason') or chunk.get('stop_reason')
                 yield stop_reason, message
             elif 'metadata' in chunk and 'usage' in chunk['metadata'] and log_to_console:
+                metadata = chunk['metadata']
                 print("\nToken usage:")
                 print(f"Input tokens: {metadata['usage']['inputTokens']}")
                 print(f"Output tokens: {metadata['usage']['outputTokens']}")


### PR DESCRIPTION
## Summary
- stream responses using `invoke_model_with_response_stream`
- remove the obsolete document message handling
- parse streaming events from `InvokeModelWithResponseStream`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f55c2446083248123944d6952732b